### PR TITLE
Added base_url support for init_ol

### DIFF
--- a/src/dspygen/utils/dspy_tools.py
+++ b/src/dspygen/utils/dspy_tools.py
@@ -11,11 +11,11 @@ def init_dspy(model: str = "gpt-3.5-turbo-instruct", lm_class=dspy.OpenAI, max_t
         return lm
 
 
-def init_ol(model: str = "phi3:instruct", max_tokens: int = 800, lm_instance=None, lm_class=dspy.OllamaLocal, timeout=10):
+def init_ol(model: str = "phi3:instruct", base_url="http://0.0.0.0:11434", max_tokens: int = 800, lm_instance=None, lm_class=dspy.OllamaLocal, timeout=10):
     if lm_instance:
         dspy.settings.configure(lm=lm_instance)
         return lm_instance
     else:
-        lm = lm_class(model=model, max_tokens=max_tokens, timeout_s=timeout)
+        lm = lm_class(model=model, base_url=base_url, max_tokens=max_tokens, timeout_s=timeout)
         dspy.settings.configure(lm=lm)
         return lm


### PR DESCRIPTION
Added the ability to specify the base_url for the OllamaLocal model, using default value of http://0.0.0.0:11434