### PR TITLE
docs: position dspygen in the Forward Deployment OS

### DIFF
--- a/FORWARD_DEPLOYMENT.md
+++ b/FORWARD_DEPLOYMENT.md
@@ -1,0 +1,32 @@
+# Forward Deployment Context
+
+This repository is part of the **Chatman Ecosystem**, a portfolio built to make forward deployment repeatable, governed, and evidence-bearing.
+
+Sean Chatman is publicly documenting the case for **The 2,001st Forward-Deployed Agentic Architect** while building the **operating system for forward deployment**.
+
+## Local role
+
+Within that portfolio, `dspygen` is an AI-assisted construction and orchestration surface. It helps manufacture structured prompts, programs, agents, interfaces, and generated implementation candidates from bounded specifications and evaluated examples.
+
+```text
+admitted requirement and examples → optimized AI program
+→ structured candidate artifact or intent → verification
+→ authority boundary → execution → receipt
+```
+
+Its forward-deployment value is not unrestricted generation. It is the compression of repeated local implementation work while keeping inputs, evaluation, generated outputs, tool boundaries, and realized consequences independently inspectable.
+
+```text
+A = μ(O*)
+R = receipt(A)
+```
+
+## Boundaries
+
+- This file does not replace the repository’s existing architecture, generators, evaluation policy, license, or exact maturity status.
+- Model output is not admitted fact, proof, or authorized action.
+- Optimized prompt/program performance remains bounded by its dataset and evaluator.
+- Generated code must cross ordinary build, test, integration, security, and release gates.
+- Tool calls and external effects require explicit authority and receipts.
+
+The canonical portfolio narrative is maintained in `seanchatmangpt/chatman-ecosystem`.


### PR DESCRIPTION
## Purpose

Position `dspygen` as an AI-assisted construction and orchestration surface within Sean Chatman’s Forward Deployment OS narrative.

## Change

- adds `FORWARD_DEPLOYMENT.md`
- maps admitted requirements and examples through optimized programs, structured candidates, verification, authority, execution, and receipts
- preserves the distinction between model output, proof, admission, and authorized effects
- introduces no source, generated output, evaluator, build, or release behavior changes

## Verification

- docs-only change
- wording reviewed against the AI-program, evaluation, generation, tool-authority, and receipt boundaries
- no generated artifact edited

## Standing

`PARTIAL_ALIVE`: local ecosystem role documented; AI-program performance and operational standing remain bounded by exact datasets, evaluators, builds, integrations, authority, and receipts.